### PR TITLE
fix: adjust module path to match github url

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Twirp RPC OpenAPI generator implemented as `protoc` plugin
 Installing the generator for protoc/buf:
 
 ```
-go install github.com/albenik-go/cmd/protoc-gen-twirp-openapi@latest
+go install github.com/albenik/twirp-openapi-gen/cmd/protoc-gen-twirp-openapi@latest
 ```
 
 ## Run whith the protoc

--- a/cmd/protoc-gen-twirp-openapi/main.go
+++ b/cmd/protoc-gen-twirp-openapi/main.go
@@ -10,7 +10,7 @@ import (
 
 	"google.golang.org/protobuf/compiler/protogen"
 
-	"github.com/albenik-go/twirp-openapi-gen/internal/openapi20"
+	"github.com/albenik/twirp-openapi-gen/internal/openapi20"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/albenik-go/twirp-openapi-gen
+module github.com/albenik/twirp-openapi-gen
 
 go 1.17
 


### PR DESCRIPTION
Adjust the module path so it matches the github url and is thus fetchable via go install